### PR TITLE
Infraestrutura inicial da VPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Terraform state files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude override files as they are usually local
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Terraform directories
+.terraform/
+
+# Sensitive files
+*.tfvars
+*.tfvars.json

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.10.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:B+2WRTvA3R5V30SehH9Z89tivr8mstZ6iCJ1s/LPQwE=",
+    "zh:3c92efebaf635372bf7283e04fc667d59b0ff3cf1aacd011fc484a11f70954d9",
+    "zh:404b2a1d360851e63f25945406f2d0c2cb9c20b361552ce01bf7fe3df516a5bf",
+    "zh:523b1640e2b9e2b548876a1dccc627c290f342255d727568fe4becfd9a8f5689",
+    "zh:697adf10c76384195303650555229129d64135f5be3abf95da0bf4b6de742054",
+    "zh:69d6177e3e106518844373871d4e6377003336761aab884da32f66b034229b5c",
+    "zh:6a41899ce8ab9cdd6f706160fd350951e5f3fc1432a37e638d3576a780c686fd",
+    "zh:6e8fd28299d6bf0ab6922cf987757e578f357a45ac45abc312688580dbde3bee",
+    "zh:7ca4bfb5a8f89586dd0c8dd9c1e638a03bc7c6f456bcc29be57cfb7bdc90fc30",
+    "zh:8fe1f6e0a2718318bae3f53a4fb77bc9eaef0fc4131145996f48482b135830c6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b221cfbc9f19ad30719b773f05f45571e88b124c15c35ac230021df1bb1110f5",
+    "zh:b458c357b5f38092e374957e51827d9113447696deccf0cb01f5684d976e7725",
+    "zh:b7fbb1b05972d73d72af58a2179ac124c6d69a4f0392aa2ce4dc855e78f52268",
+    "zh:d95da0dc45df0f30005e17c5206addbd62b0471c265d9855fe8039bf6f2adef7",
+    "zh:db5dd4120c6ab6ae13df67353a9bc902ac34d01c1d297812d628ebf61dc6f681",
+  ]
+}

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "bucket-for-backend-tf-fastfood-soat"
+    key    = "dev/terraform/terraform.tfstate"
+    region = "sa-east-1"
+  }
+}

--- a/bucket-backend.tf
+++ b/bucket-backend.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "bucket-backend" {
+  bucket = "bucket-for-backend-tf-fastfood-soat"
+
+  tags = {
+    Name        = "safe local to save tfstate"
+    Environment = "by terraform"
+  }
+}

--- a/private-subnet.tf
+++ b/private-subnet.tf
@@ -1,0 +1,10 @@
+resource "aws_subnet" "private" {
+  vpc_id     = aws_vpc.fastfood-vpc.id
+  cidr_block = "10.0.2.0/24"
+  map_public_ip_on_launch = false
+  availability_zone = "sa-east-1a"
+
+  tags = {
+    Name = "private-subnet"
+  }
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = "sa-east-1"
+}

--- a/public-subnet.tf
+++ b/public-subnet.tf
@@ -1,0 +1,10 @@
+resource "aws_subnet" "public" {
+  vpc_id     = aws_vpc.fastfood-vpc.id
+  cidr_block = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  availability_zone = "sa-east-1a"
+
+  tags = {
+    Name = "public-subnet"
+  }
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,7 @@
+# VPC
+resource "aws_vpc" "fastfood-vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "fastfood-vpc"
+  }
+}


### PR DESCRIPTION
Este PR adiciona a infraestrutura básica no AWS usando Terraform:

- VPC principal
- Subnets públicas e privadas em duas AZs (a e b)
- Internet Gateway
- Route Table pública e associações com subnets públicas
- Backend S3 configurado para armazenar o Terraform state
- Variables para centralizar dados da infraestrutura
- README atualizado com comando AWS CLI para criação do bucket S3
- Outputs da VPC e subnets


